### PR TITLE
Changed color of text in index page

### DIFF
--- a/style-landing.css
+++ b/style-landing.css
@@ -50,7 +50,7 @@ body {
     text-align: center;
     align-items: center;
     justify-content: center;
-    color: #2cbdc2;
+    color: #228426;
     overflow: hidden;
 }
 


### PR DESCRIPTION
As in index page of Mindspace-Web the color of text was not matching with the contents of the page and some letters were not clearly visible. 
<img width="953" alt="Screenshot 2024-01-24 000836" src="https://github.com/The-MindSpace/MindSpace-Web/assets/99176636/ae0477ff-c450-498d-b108-02e251b57048">

So, I would like to change its color to its matching content.
<img width="954" alt="Screenshot 2024-01-24 001555" src="https://github.com/The-MindSpace/MindSpace-Web/assets/99176636/19a52848-0baf-472a-8b49-c22261433a3a">

So, please assign this issue to me, under SWOC.